### PR TITLE
Add Rspec Max Configurations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,20 +3,20 @@ PATH
   specs:
     transreport-style (0.1.0)
       rubocop-performance (~> 1.11)
-      rubocop-rails (~> 2.10)
-      rubocop-rspec (~> 2.3)
+      rubocop-rails (~> 2.11)
+      rubocop-rspec (~> 2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
@@ -27,25 +27,25 @@ GEM
     rainbow (3.0.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.15.0)
+    rubocop (1.18.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.6.0)
+    rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.11.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.10.1)
+    rubocop-rails (2.11.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    rubocop-rspec (2.3.0)
+    rubocop-rspec (2.4.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
@@ -55,6 +55,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ which can be loaded into other repos with ease.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'transreport-style', git: 'https://github.com/TRANSREPORT/transreport-style', tag: 'v0.1.0'
+gem 'transreport-style', git: 'https://github.com/TRANSREPORT/transreport-style', tag: 'v0.2.0'
 ```
 
 And then execute:

--- a/lib/transreport/style/version.rb
+++ b/lib/transreport/style/version.rb
@@ -2,6 +2,6 @@
 
 module Transreport
   module Style
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/transreport-rails.yml
+++ b/transreport-rails.yml
@@ -29,9 +29,6 @@ Metrics/BlockLength:
 Rspec/ExampleLength:
   Max: 15
 
-Rspec/MultipleExpectations:
-  Max: 5
-
 Rspec/NestedGroups:
   Max: 5
 

--- a/transreport-rails.yml
+++ b/transreport-rails.yml
@@ -26,6 +26,15 @@ Metrics/BlockLength:
     - 'config/**/*'
     - 'spec/**/*'
 
+Rspec/ExampleLength:
+  Max: 15
+
+Rspec/MultipleExpectations:
+  Max: 5
+
+Rspec/NestedGroups:
+  Max: 5
+
 Style/NumericLiteralPrefix:
   Exclude:
     - 'spec/**/*'

--- a/transreport-rails.yml
+++ b/transreport-rails.yml
@@ -26,9 +26,6 @@ Metrics/BlockLength:
     - 'config/**/*'
     - 'spec/**/*'
 
-Rspec/ExampleLength:
-  Max: 15
-
 Rspec/NestedGroups:
   Max: 5
 

--- a/transreport-style.gemspec
+++ b/transreport-style.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rubocop-performance', '~> 1.11'
-  spec.add_dependency 'rubocop-rails', '~> 2.10'
-  spec.add_dependency 'rubocop-rspec', '~> 2.3'
+  spec.add_dependency 'rubocop-rails', '~> 2.11'
+  spec.add_dependency 'rubocop-rspec', '~> 2.4'
 end


### PR DESCRIPTION
**Description:**

As per title

Rubocop Rules changed:

[Rspec/NestedGroups](https://docs.rubocop.org/rubocop-rspec/2.1/cops_rspec.html#rspecnestedgroups) - Voted to move from default of 3 to 5. This allows multiple indentations within the file of up to 5, after viewing team was happy to raise the number as it didn't make the code less readable. 5 was the max amount that Defect Report had and on team inspection the amount of indentation was deemed suitable to raise as the Max value

Rubocop Rules shelved for future discussion:

[Rspec/ExampleLength](https://docs.rubocop.org/rubocop-rspec/2.1/cops_rspec.html#rspecexamplelength) - voted to raise from 5 to 15 across all codebases as 5 was too restricting and those of around around 15 still looked neat and necessary

[Rspec/MultipleExpectations](https://docs.rubocop.org/rubocop-rspec/2.2/cops_rspec.html#rspecmultipleexpectations) removed back to default to avoid additional rubocop.yml files. Agreed upon team solution for up to 5 MultipleExpectations is the use of `Aggregate features` block with expects placed within the block.

**Ticket/Issue Reference:**  

**Testing Plan:**

Pipeline

**Breaking Changes**:

- [x] Any breaking changes have been disclosed to the relevant party/parties

**Checklist:**

- [x] [Accompanying documentation](https://transreport.atlassian.net/wiki/spaces/ENG/pages/1766752263/What+is+Accompanying+Documentation) provided (where necessary)
- [ ] Manual testing was successful
- [x] Automated tests cover the content of this PR
- [x] PR appropriately labelled
- [x] Reviewers and assignees appropriately set
- [x] Tickets raised for any out-of-scope work identified 
