### PR TITLE
WT-179: Exclude engines folder from check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project should be documented in this file, in one of
 ### Added / Changed / Fixed / Removed / Tested
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.3.0 (2021-07-22)
+### Added
+- Exclude engines folder from check
+
+## v0.2.0 (2021-07-20)
+### Changed
+- Add max configurations to rspec rules
 
 ## v0.1.0 (2021-05-27)
 ### Added

--- a/lib/transreport/style/version.rb
+++ b/lib/transreport/style/version.rb
@@ -2,6 +2,6 @@
 
 module Transreport
   module Style
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/transreport-rails.yml
+++ b/transreport-rails.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'vendor/**/*'
     - 'node_modules/**/*'
     - 'tmp/**/*'
+    - 'engines/**/*'
 
 Layout/LineLength:
   Max: 100


### PR DESCRIPTION
**Description:**

Exclude engines folder from rubocop check

**Ticket/Issue Reference:**  [WT-179](https://transreport.atlassian.net/browse/WT-179)

**Testing Plan:**

Overview of testing plan goes here

**Breaking Changes**:

- [ ] Any breaking changes have been disclosed to the relevant party/parties

* List of breaking changes where necessary (relevant party if applicable)

**Notes:**

Any additional notes go here

**Deployment:**

* List of deployment notes, such as database migrations, build instructions or one-off tasks

- [ ] All deployment notes have been disclosed by this point and the relevant parties have been made aware

**Resources:**

Resources go here

**Checklist:**

- [ ] [Accompanying documentation](https://transreport.atlassian.net/wiki/spaces/ENG/pages/1766752263/What+is+Accompanying+Documentation) provided (where necessary)
- [ ] Manual testing was successful
- [ ] Automated tests cover the content of this PR
- [ ] PR appropriately labelled
- [ ] Reviewers and assignees appropriately set
- [ ] Tickets raised for any out-of-scope work identified 
