### PR TITLE
WT-216: Exclude lib/tasks from check

### DIFF
--- a/transreport-rails.yml
+++ b/transreport-rails.yml
@@ -27,6 +27,7 @@ Metrics/BlockLength:
   Exclude:
     - 'config/**/*'
     - 'spec/**/*'
+    - 'lib/tasks/**/*'
 
 RSpec/NestedGroups:
   Max: 5


### PR DESCRIPTION
**Description:**

Exclude `lib/tasks` from the check 

**Ticket/Issue Reference:**  [wt-216](https://transreport.atlassian.net/browse/WT-216)

**Testing Plan:**

Overview of testing plan goes here

**Breaking Changes**:

- [ ] Any breaking changes have been disclosed to the relevant party/parties

* List of breaking changes where necessary (relevant party if applicable)

**Notes:**

Any additional notes go here

**Deployment:**

* List of deployment notes, such as database migrations, build instructions or one-off tasks

- [ ] All deployment notes have been disclosed by this point and the relevant parties have been made aware

**Resources:**

Resources go here

**Checklist:**

- [ ] [Accompanying documentation](https://transreport.atlassian.net/wiki/spaces/ENG/pages/1766752263/What+is+Accompanying+Documentation) provided (where necessary)
- [ ] Manual testing was successful
- [ ] Automated tests cover the content of this PR
- [ ] PR appropriately labelled
- [ ] Reviewers and assignees appropriately set
- [ ] Tickets raised for any out-of-scope work identified 
